### PR TITLE
Added script for NVIDIA HWAccel support in Firefox

### DIFF
--- a/nvidia-envvars.sh
+++ b/nvidia-envvars.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Check system for NVIDIA card and set env vars
+
+if [[ $(lshw -C display | grep vendor) =~ Nvidia ]]; then
+        export LIBVA_DRIVER_NAME=nvidia
+        export MOZ_DISABLE_RDD_SANDBOX=1
+        export EGL_PLATFORM=wayland
+else
+        echo "No NVIDIA GPU detected. No env vars set."
+fi


### PR DESCRIPTION
Not sure about where to put it, though.

**It's just the environment variables for the system, not for FF**. Those have to be enabled manually.